### PR TITLE
Fix : Firefox not running, not able to scrape on web app nor open the the desktop app -> Firefox timeout 120sec

### DIFF
--- a/docrawl/docrawl_client.py
+++ b/docrawl/docrawl_client.py
@@ -1,3 +1,10 @@
+import asyncio
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+
+from twisted.internet import asyncioreactor
+asyncioreactor.install()
+
 import itertools
 import time
 from contextlib import suppress
@@ -11,7 +18,6 @@ from docrawl.docrawl_core import DocrawlSpider
 from docrawl.docrawl_logger import docrawl_logger
 from docrawl.errors import PageDidNotLoadError, SpiderFunctionError
 from keepvariable.keepvariable_core import KeepVariableDummyRedisServer
-
 
 @dataclass
 class DocrawlSettings:
@@ -197,6 +203,9 @@ class DocrawlClient:
         self._execute_function('restart_browser', None, timeout=120)
 
     def load_website(self, url, timeout=20):
+        if self.get_browser_meta_data() is None:
+            self._initialize_browser_metadata(driver='Firefox', headless=True)
+            
         if "http" not in url:
             url = "http://" + url
 


### PR DESCRIPTION
Fix for the not able to use dektop app on the linux ubuntu nor be able to run scraping on web app.